### PR TITLE
Speed up log message filtering

### DIFF
--- a/lib/telemetry/logger/console_logger.rb
+++ b/lib/telemetry/logger/console_logger.rb
@@ -52,7 +52,7 @@ class Telemetry
       end
 
       def level=(level)
-        index = levels.index(level)
+        index = ordinal(level)
 
         raise "Unknown logger level: #{level}" unless index
 

--- a/lib/telemetry/logger/levels.rb
+++ b/lib/telemetry/logger/levels.rb
@@ -22,10 +22,6 @@ class Telemetry
         ]
       end
 
-      def levels
-        Levels.levels
-      end
-
       def self.included(cls)
         levels.each do |level|
           define_level level, cls
@@ -38,8 +34,26 @@ class Telemetry
         end
       end
 
+      def self.level_index
+        @level_index ||= build_level_index
+      end
+
+      def self.build_level_index
+        table = {}
+
+        levels.each_with_index do |level, index|
+          table[level] = index
+        end
+
+        table
+      end
+
+      def level_index
+        Levels.level_index
+      end
+
       def ordinal(level)
-        levels.index(level)
+        level_index[level]
       end
 
       def write_level(level, message)


### PR DESCRIPTION
By precalculating the mapping of level names, e.g. `:info`, to ordinal numbers, e.g. `3`, we can compare the log level of the message with the log level of the logger in constant time. This substantially improves the performance of the logger when it skips messages that are below the logger level.

There are many other optimizations that can be done, but this was easy "low hanging fruit."
